### PR TITLE
Run OONI v2.2.0 from debian 8

### DIFF
--- a/.github/workflows/dockerrunner.yml
+++ b/.github/workflows/dockerrunner.yml
@@ -11,6 +11,7 @@ jobs:
       fail-fast: false
       matrix:
         runner:
+        - legacydebian8
         - legacydebian9
         - miniooni
     steps:

--- a/docker/legacydebian8/Dockerfile
+++ b/docker/legacydebian8/Dockerfile
@@ -1,0 +1,12 @@
+FROM debian:8
+RUN apt-get update
+RUN apt-get install -y build-essential libdumbnet-dev libpcap-dev tor \
+        libgeoip-dev libffi-dev python-dev python-pip libssl-dev
+WORKDIR /ooni
+ADD requirements.txt /ooni
+RUN pip install -r requirements.txt
+RUN apt-get install -y curl
+RUN curl -fsSLO https://github.com/ooni/probe-legacy/archive/v2.2.0.tar.gz
+RUN tar -xzf v2.2.0.tar.gz
+WORKDIR /ooni/probe-legacy-2.2.0
+RUN python setup.py install

--- a/docker/legacydebian8/requirements.txt
+++ b/docker/legacydebian8/requirements.txt
@@ -1,0 +1,39 @@
+# Using macOS homebrew package dependencies versions
+# https://github.com/Homebrew/homebrew-core/blob/master/Formula/ooniprobe.rb
+pyasn1==0.2.3
+setuptools==11.3
+
+# These are direct dependencies of ooniprobe.
+PyYAML==3.12
+Twisted==17.1.0
+ipaddr==2.1.11
+pyOpenSSL==16.2.0
+geoip==1.3.2
+txtorcon==0.18.0
+txsocksx==1.15.0.2
+scapy==2.3.3
+pypcap==1.2.1
+service-identity==16.0.0
+pydumbnet==1.12.1
+zope.interface==4.3.3
+certifi==2017.1.23
+klein==17.2.0
+
+# These are indirect dependencies of ooniprobe.
+cffi==1.9.1
+enum34==1.1.6
+pycparser==2.17
+appdirs==1.4.3
+asn1crypto==0.21.1
+attrs==16.3.0
+Automat==0.5.0
+constantly==15.1.0
+cryptography==1.8.1
+idna==2.5
+incremental==16.10.1
+ipaddress==1.0.18
+packaging==16.8
+Parsley==1.3
+pyasn1-modules==0.0.8
+pyparsing==2.2.0
+werkzeug==0.12

--- a/script/legacydebian8
+++ b/script/legacydebian8
@@ -1,0 +1,4 @@
+#!/bin/bash
+set -ex
+docker build -t legacydebian8 ./docker/legacydebian8
+docker run -v`pwd`:/ooni -w/ooni legacydebian8 ./script/legacycore /var/lib/ooni


### PR DESCRIPTION
This loosely matches what happens with lepidopter. We started
distributing lepidopter in the summer of 2016. We were certainly
using Debian 8 at the time. Also, we were probably using a version
of OONI that was lesser than v2.2.0, which was released on April
2017. But there is also auto-updating, so it's not fully clear to
me what is the right approach here.

Another aspect to consider is that I have pinned all the dependencies
to the dependencies that are used by OONI v2.3.0, because not pinning in
a precise way the depedencies is going to cause failures.

That is, the pursuit of the correct combination of dependencies that
faithfully represent lepidtoper is not so easy.

(It's true that there is a list of pinned dependencies at
github.com/TheTorProject/lepidopter but these dependencies
are not sufficient to avoid build errors.)

This is part of https://github.com/ooni/backend/issues/446.