### PR TITLE
github/workflows: refactor runners to be independent

### DIFF
--- a/.github/workflows/legacydarwin.yml
+++ b/.github/workflows/legacydarwin.yml
@@ -1,0 +1,21 @@
+name: legacydarwin
+on:
+  pull_request:
+  push:
+  schedule:
+    - cron: "0 */4 * * *"
+jobs:
+  test:
+    runs-on: macos-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        runner:
+        - legacydarwin
+    steps:
+      - if: "${{ matrix.runner == 'miniooni' }}"
+        uses: actions/setup-go@v1
+        with:
+          go-version: "1.14"
+      - uses: actions/checkout@v2
+      - run: "./script/${{ matrix.runner }}"

--- a/.github/workflows/legacydebian8.yml
+++ b/.github/workflows/legacydebian8.yml
@@ -1,0 +1,21 @@
+name: legacydebian8
+on:
+  pull_request:
+  push:
+  schedule:
+    - cron: "0 */4 * * *"
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        runner:
+        - legacydebian8
+    steps:
+      - if: "${{ matrix.runner == 'miniooni' }}"
+        uses: actions/setup-go@v1
+        with:
+          go-version: "1.14"
+      - uses: actions/checkout@v2
+      - run: "./script/${{ matrix.runner }}"

--- a/.github/workflows/legacydebian9.yml
+++ b/.github/workflows/legacydebian9.yml
@@ -1,4 +1,4 @@
-name: dockerrunner
+name: legacydebian9
 on:
   pull_request:
   push:
@@ -11,9 +11,7 @@ jobs:
       fail-fast: false
       matrix:
         runner:
-        - legacydebian8
         - legacydebian9
-        - miniooni
     steps:
       - if: "${{ matrix.runner == 'miniooni' }}"
         uses: actions/setup-go@v1

--- a/.github/workflows/measurementkit.yml
+++ b/.github/workflows/measurementkit.yml
@@ -1,4 +1,4 @@
-name: macosrunner
+name: measurementkit
 on:
   pull_request:
   push:
@@ -11,9 +11,7 @@ jobs:
       fail-fast: false
       matrix:
         runner:
-        - legacydarwin
         - measurementkit
-        - miniooni
     steps:
       - if: "${{ matrix.runner == 'miniooni' }}"
         uses: actions/setup-go@v1

--- a/.github/workflows/miniooni.yml
+++ b/.github/workflows/miniooni.yml
@@ -1,0 +1,24 @@
+name: miniooni
+on:
+  pull_request:
+  push:
+  schedule:
+    - cron: "0 */4 * * *"
+jobs:
+  test:
+    runs-on: "${{ matrix.os }}"
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+        - ubuntu-latest
+        - macos-latest
+        runner:
+        - miniooni
+    steps:
+      - if: "${{ matrix.runner == 'miniooni' }}"
+        uses: actions/setup-go@v1
+        with:
+          go-version: "1.14"
+      - uses: actions/checkout@v2
+      - run: "./script/${{ matrix.runner }}"


### PR DESCRIPTION
Simplifies restarting in case there's a failure. Also this
enables adding a badges matrix in README.md.

Part of https://github.com/ooni/backend/issues/446.