### PR TITLE
Make the config/backend folder unnecessary

### DIFF
--- a/.github/workflows/measurementkit.yml
+++ b/.github/workflows/measurementkit.yml
@@ -7,15 +7,10 @@ on:
 jobs:
   test:
     runs-on: macos-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        runner:
-        - measurementkit
     steps:
       - uses: actions/setup-go@v1
         with:
           go-version: "1.14"
       - uses: actions/checkout@v2
-      - run: "./script/${{ matrix.runner }}"
+      - run: ./script/measurementkit https://ams-pg.ooni.org
       - run: go run ./script/postprocess.go

--- a/config/backend/https
+++ b/config/backend/https
@@ -1,1 +1,0 @@
-https://ams-pg.ooni.org

--- a/config/backend/onion
+++ b/config/backend/onion
@@ -1,1 +1,0 @@
-httpo://guegdifjy7bjpequ.onion

--- a/script/measurementkit
+++ b/script/measurementkit
@@ -6,7 +6,8 @@ for f in asn.mmdb.gz ca-bundle.pem.gz country.mmdb.gz; do
   curl -fsSLO https://github.com/ooni/probe-assets/releases/download/20200821081345/$f
   gunzip -f $f
 done
-measurement_kit --bouncer $(cat ./config/backend/https)  \
+test $# -eq 1 || exit 1
+measurement_kit --bouncer $1                             \
                 -o output/mk.jsonl                       \
                 --ca-bundle-path ca-bundle.pem           \
                 --geoip-country-path country.mmdb        \


### PR DESCRIPTION
Always configure using github actions. Means we can configure more
than a single target at a given time, with advantages.

See https://github.com/ooni/backend/issues/446