### PR TITLE
ooniprobe210debian9: use vagrant rather than docker

### DIFF
--- a/.github/workflows/ooniprobe210debian9.yml
+++ b/.github/workflows/ooniprobe210debian9.yml
@@ -13,6 +13,6 @@ jobs:
           go-version: "1.14"
       - uses: actions/checkout@v2
       - run: vagrant plugin install vagrant-scp
-      - run: cd ./vagarant/ooniprobe210debian9 && vagrant up
+      - run: cd ./vagrant/ooniprobe210debian9 && vagrant up
       - run: vagrant scp :/vagrant/*.jsonl ./output/
       - run: go run ./script/postprocess.go

--- a/.github/workflows/ooniprobe210debian9.yml
+++ b/.github/workflows/ooniprobe210debian9.yml
@@ -14,5 +14,5 @@ jobs:
       - uses: actions/checkout@v2
       - run: vagrant plugin install vagrant-scp
       - run: cd ./vagrant/ooniprobe210debian9 && vagrant up
-      - run: vagrant scp :/vagrant/*.jsonl ./output/
+      - run: cd ./vagrant/ooniprobe210debian9 && vagrant scp :/vagrant/*.jsonl ./output/
       - run: go run ./script/postprocess.go

--- a/.github/workflows/ooniprobe210debian9.yml
+++ b/.github/workflows/ooniprobe210debian9.yml
@@ -14,5 +14,5 @@ jobs:
       - uses: actions/checkout@v2
       - run: vagrant plugin install vagrant-scp
       - run: cd ./vagrant/ooniprobe210debian9 && vagrant up
-      - run: cd ./vagrant/ooniprobe210debian9 && vagrant scp :/vagrant/*.jsonl ./output/
+      - run: cd ./vagrant/ooniprobe210debian9 && vagrant scp :/vagrant/*.jsonl ../output/
       - run: go run ./script/postprocess.go

--- a/.github/workflows/ooniprobe210debian9.yml
+++ b/.github/workflows/ooniprobe210debian9.yml
@@ -14,5 +14,5 @@ jobs:
       - uses: actions/checkout@v2
       - run: vagrant plugin install vagrant-scp
       - run: cd ./vagrant/ooniprobe210debian9 && vagrant up
-      - run: cd ./vagrant/ooniprobe210debian9 && vagrant scp :/vagrant/*.jsonl ../output/
+      - run: cd ./vagrant/ooniprobe210debian9 && vagrant scp :/vagrant/*.jsonl ../../output/
       - run: go run ./script/postprocess.go

--- a/.github/workflows/ooniprobe210debian9.yml
+++ b/.github/workflows/ooniprobe210debian9.yml
@@ -6,17 +6,13 @@ on:
     - cron: "0 */4 * * *"
 jobs:
   test:
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        options:
-        - "/var/lib/ooni https://ams-pg.ooni.org httpo://guegdifjy7bjpequ.onion"
+    runs-on: macos-latest
     steps:
       - uses: actions/setup-go@v1
         with:
           go-version: "1.14"
       - uses: actions/checkout@v2
-      - run: docker build -t x ./docker/ooniprobe210debian9
-      - run: docker run -v`pwd`:/ooni -w/ooni x ./script/ooniprobe ${{ matrix.options }}
+      - run: vagrant plugin install vagrant-scp
+      - run: cd ./vagarant/ooniprobe210debian9 && vagrant up
+      - run: vagrant scp :/vagrant/*.jsonl ./output/
       - run: go run ./script/postprocess.go

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.vagrant/
 /asn.mmdb
 /ca-bundle.pem
 /country.mmdb

--- a/docker/ooniprobe210debian9/Dockerfile
+++ b/docker/ooniprobe210debian9/Dockerfile
@@ -1,6 +1,0 @@
-FROM debian:9
-RUN echo deb http://deb.debian.org/debian/ stretch contrib | tee -a /etc/apt/sources.list
-RUN apt-get update
-RUN apt-get install -y locales
-RUN locale-gen en_US.UTF-8
-RUN apt-get install -y ooniprobe

--- a/vagrant/ooniprobe210debian9/Vagrantfile
+++ b/vagrant/ooniprobe210debian9/Vagrantfile
@@ -5,9 +5,9 @@ Vagrant.configure("2") do |config|
     apt-get update
     apt-get install -y ooniprobe
     touch /var/lib/ooni/initialized
-    ooniprobe -P https --bouncer=https://ams-pg.ooni.org -o output/legacy_https.jsonl \
+    ooniprobe -P https --bouncer=https://ams-pg.ooni.org -o /vagrant/legacy_https.jsonl \
         web_connectivity -u http://mail.google.com
-    ooniprobe -P onion --bouncer=httpo://guegdifjy7bjpequ.onion -o output/legacy_onion.jsonl \
+    ooniprobe -P onion --bouncer=httpo://guegdifjy7bjpequ.onion -o /vagrant/legacy_onion.jsonl \
         web_connectivity -u http://mail.google.com
   SHELL
 end

--- a/vagrant/ooniprobe210debian9/Vagrantfile
+++ b/vagrant/ooniprobe210debian9/Vagrantfile
@@ -1,0 +1,13 @@
+Vagrant.configure("2") do |config|
+  config.vm.box = "debian/stretch64"
+  config.vm.provision "shell", inline: <<-SHELL
+    echo deb http://deb.debian.org/debian/ stretch contrib | sudo tee -a /etc/apt/sources.list
+    apt-get update
+    apt-get install -y ooniprobe
+    touch /var/lib/ooni/initialized
+    ooniprobe -P https --bouncer=https://ams-pg.ooni.org -o output/legacy_https.jsonl \
+        web_connectivity -u http://mail.google.com
+    ooniprobe -P onion --bouncer=httpo://guegdifjy7bjpequ.onion -o output/legacy_onion.jsonl \
+        web_connectivity -u http://mail.google.com
+  SHELL
+end


### PR DESCRIPTION
While slower, vagrant emulates a complete environment. This may be a
more comprehensive way of running a legacy probe.

Part of https://github.com/ooni/backend/issues/446