### PR TITLE
github/workflows: run ooniprobe v2.2.0 in debian9

### DIFF
--- a/.github/workflows/ooniprobe220debian9.yml
+++ b/.github/workflows/ooniprobe220debian9.yml
@@ -1,0 +1,18 @@
+name: ooniprobe220debian9
+on:
+  pull_request:
+  push:
+  schedule:
+    - cron: "0 */4 * * *"
+jobs:
+  test:
+    runs-on: macos-latest
+    steps:
+      - uses: actions/setup-go@v1
+        with:
+          go-version: "1.14"
+      - uses: actions/checkout@v2
+      - run: vagrant plugin install vagrant-scp
+      - run: cd ./vagrant/ooniprobe220debian9 && vagrant up
+      - run: cd ./vagrant/ooniprobe220debian9 && vagrant scp :/vagrant/*.jsonl ../../output/
+      - run: go run ./script/postprocess.go

--- a/vagrant/ooniprobe220debian9/Vagrantfile
+++ b/vagrant/ooniprobe220debian9/Vagrantfile
@@ -1,0 +1,14 @@
+Vagrant.configure("2") do |config|
+  config.vm.box = "debian/stretch64"
+  config.vm.provision "shell", inline: <<-SHELL
+    # 2.2.0 was added in buster for testing around this date
+    echo "deb [check-valid-until=no] http://snapshot.debian.org/archive/debian/20171218T153801Z/ buster contrib" | sudo tee -a /etc/apt/sources.list
+    apt-get update
+    apt-get install -y ooniprobe
+    touch /var/lib/ooni/initialized
+    ooniprobe -P https --bouncer=https://ams-pg.ooni.org -o /vagrant/legacy_https.jsonl \
+        web_connectivity -u http://mail.google.com
+    ooniprobe -P onion --bouncer=httpo://guegdifjy7bjpequ.onion -o /vagrant/legacy_onion.jsonl \
+        web_connectivity -u http://mail.google.com
+  SHELL
+end


### PR DESCRIPTION
We're using snapshots to get v2.2.0 inside debian9 from testing.

See https://github.com/ooni/backend/issues/446#issuecomment-697172389