### PR TITLE
workflows: run MK 0.10.11 in Alpine Linux

### DIFF
--- a/.github/workflows/linuxmk0.10.11.yml
+++ b/.github/workflows/linuxmk0.10.11.yml
@@ -1,0 +1,29 @@
+name: libmk0.10.11
+on:
+  pull_request:
+  push:
+  schedule:
+    - cron: "0 */4 * * *"
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/setup-go@v1
+        with:
+          go-version: "1.14"
+      - uses: actions/checkout@v2
+      - run: |
+          bouncer=https://ams-pg.ooni.org
+          for f in asn.mmdb.gz ca-bundle.pem.gz country.mmdb.gz; do
+            curl -fsSLO https://github.com/ooni/probe-assets/releases/download/20200821081345/$f
+            gunzip -f $f
+          done
+          docker run -v`pwd`:/mk -w/mk openobservatory/mk-alpine:20200226 \
+            measurement_kit --bouncer $bouncer                            \
+                -o output/mk.jsonl                                        \
+                --ca-bundle-path ca-bundle.pem                            \
+                --geoip-country-path country.mmdb                         \
+                --geoip-asn-path asn.mmdb                                 \
+                web_connectivity                                          \
+                -u http://mail.google.com
+      - run: go run ./script/postprocess.go


### PR DESCRIPTION
This is very close to ooniprobe-cli 3.0.0 under Linux.

Part of https://github.com/ooni/backend/issues/446#issuecomment-697172389