### PR TITLE
.github/workflows: less frequent more spaced in time runs

### DIFF
--- a/.github/workflows/debian9.yml
+++ b/.github/workflows/debian9.yml
@@ -9,7 +9,7 @@ on:
   pull_request:
   push:
   schedule:
-    - cron: "*/34 * * * *"
+    - cron: "0 */2 * * *"
 jobs:
   test:
     runs-on: macos-latest

--- a/.github/workflows/linuxmk0.10.11.yml
+++ b/.github/workflows/linuxmk0.10.11.yml
@@ -8,7 +8,7 @@ on:
   pull_request:
   push:
   schedule:
-    - cron: "*/34 * * * *"
+    - cron: "5 */2 * * *"
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/macos10.15.yml
+++ b/.github/workflows/macos10.15.yml
@@ -7,7 +7,7 @@ on:
   pull_request:
   push:
   schedule:
-    - cron: "*/34 * * * *"
+    - cron: "10 */2 * * *"
 jobs:
   test:
     runs-on: macos-10.15

--- a/.github/workflows/measurementkit.yml
+++ b/.github/workflows/measurementkit.yml
@@ -5,7 +5,7 @@ on:
   pull_request:
   push:
   schedule:
-    - cron: "*/34 * * * *"
+    - cron: "15 */2 * * *"
 jobs:
   test:
     runs-on: macos-10.15

--- a/.github/workflows/probeengine.yml
+++ b/.github/workflows/probeengine.yml
@@ -7,7 +7,7 @@ on:
   pull_request:
   push:
   schedule:
-    - cron: "*/34 * * * *"
+    - cron: "20 */2 * * *"
 jobs:
   test:
     runs-on: "ubuntu-18.04"

--- a/.github/workflows/probeengine1.yml
+++ b/.github/workflows/probeengine1.yml
@@ -6,7 +6,7 @@ on:
   pull_request:
   push:
   schedule:
-    - cron: "*/34 * * * *"
+    - cron: "25 */2 * * *"
 jobs:
   test:
     runs-on: "ubuntu-18.04"

--- a/.github/workflows/probeengine2.yml
+++ b/.github/workflows/probeengine2.yml
@@ -6,7 +6,7 @@ on:
   pull_request:
   push:
   schedule:
-    - cron: "*/34 * * * *"
+    - cron: "30 */2 * * *"
 jobs:
   test:
     runs-on: "ubuntu-18.04"


### PR DESCRIPTION
I've seen a couple of 429 failures recently. So, I believe it's best
to run less frequent more spaced in time tests.

We want to continue testing the backend but we also don't want to be
distracted by random false positives caused by 429.