### PR TITLE
Start probing the testing cloudfronted endpoint

### DIFF
--- a/.github/workflows/macos10.15.yml
+++ b/.github/workflows/macos10.15.yml
@@ -16,11 +16,14 @@ jobs:
         with:
           go-version: "1.14"
       - uses: actions/checkout@v2
+      # Limitation: we test the cloudfronted endpoint as a normal HTTPS endpoint.
       - run: |
           brew install ooniprobe
           install -d $HOME/.ooni
           touch $HOME/.ooni/initialized
           ooniprobe -P https --bouncer=https://ams-pg.ooni.org -o ./output/https.jsonl \
+            web_connectivity -u http://mail.google.com
+          ooniprobe -P https --bouncer=https://dvp6h0xblpcqp.cloudfront.net -o ./output/https.jsonl \
             web_connectivity -u http://mail.google.com
           ooniprobe -P onion --bouncer=httpo://guegdifjy7bjpequ.onion -o ./output/onion.jsonl \
             web_connectivity -u http://mail.google.com

--- a/.github/workflows/probeengine.yml
+++ b/.github/workflows/probeengine.yml
@@ -18,6 +18,7 @@ jobs:
         - "master"
         options:
         - "--probe-services=https://ams-pg.ooni.org -o output/miniooni.jsonl"
+        - "--probe-services=https://dvp6h0xblpcqp.cloudfront.net -o output/miniooni.jsonl"
     steps:
       - uses: actions/setup-go@v1
         with:

--- a/vagrant/debian9/bootstrap
+++ b/vagrant/debian9/bootstrap
@@ -4,7 +4,10 @@ echo "$@" | tee -a /etc/apt/sources.list
 apt-get update
 apt-get install -y ooniprobe
 touch /var/lib/ooni/initialized
+# Limitation: we test the cloudfronted endpoint as a normal HTTPS endpoint.
 ooniprobe -P https --bouncer=https://ams-pg.ooni.org -o /vagrant/https.jsonl \
+    web_connectivity -u http://mail.google.com
+ooniprobe -P https --bouncer=https://dvp6h0xblpcqp.cloudfront.net -o ./output/https.jsonl \
     web_connectivity -u http://mail.google.com
 ooniprobe -P onion --bouncer=httpo://guegdifjy7bjpequ.onion -o /vagrant/onion.jsonl \
     web_connectivity -u http://mail.google.com


### PR DESCRIPTION
Because it's not immediately obvious to me what is the correct way to
force a cloudfronted bouncer, I am using a simple strategy for now where
we treat the cloudfronted URL as a normal HTTPS URL.

What are we testing here? Well, I would say that we're checking whether
different incarnations of the probe can speak to the cloudfronted backend.

We're not testing MK because it does not support cloudfronting.

Part of https://github.com/ooni/backend/issues/451.