### PR TITLE
feat: add e2etest for debian package

### DIFF
--- a/.github/workflows/debian9.yml
+++ b/.github/workflows/debian9.yml
@@ -11,7 +11,7 @@ on:
   pull_request:
   push:
   schedule:
-    - cron: "0 */2 * * *"
+    - cron: "0 */8 * * *"
 jobs:
   test:
     runs-on: macos-latest

--- a/.github/workflows/linuxmk0.10.11.yml
+++ b/.github/workflows/linuxmk0.10.11.yml
@@ -11,7 +11,7 @@ on:
   pull_request:
   push:
   schedule:
-    - cron: "5 */2 * * *"
+    - cron: "5 */8 * * *"
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/macos10.15.yml
+++ b/.github/workflows/macos10.15.yml
@@ -10,7 +10,7 @@ on:
   pull_request:
   push:
   schedule:
-    - cron: "10 */2 * * *"
+    - cron: "10 */8* * *"
 jobs:
   test:
     runs-on: macos-10.15

--- a/.github/workflows/measurementkit.yml
+++ b/.github/workflows/measurementkit.yml
@@ -13,7 +13,7 @@ on:
   pull_request:
   push:
   schedule:
-    - cron: "15 */2 * * *"
+    - cron: "15 */8 * * *"
 jobs:
   test:
     runs-on: macos-10.15

--- a/.github/workflows/ooniprobe3debian.yml
+++ b/.github/workflows/ooniprobe3debian.yml
@@ -17,4 +17,5 @@ jobs:
       - run: echo "deb [trusted=yes] https://dl.bintray.com/ooni/ooniprobe-debian/ unstable main" | sudo tee -a /etc/apt/sources.list.d/ooniprobe.list
       - run: sudo apt update
       - run: sudo apt install ooniprobe
+      - run: ooniprobe onboard --yes
       - run: ooniprobe ${{ matrix.extraoptions }} im

--- a/.github/workflows/ooniprobe3debian.yml
+++ b/.github/workflows/ooniprobe3debian.yml
@@ -1,0 +1,20 @@
+name: ooniprobe3debian
+on:
+  pull_request:
+  push:
+  schedule:
+    - cron: "20 */8 * * *"
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        extraoptions:
+        - ""
+    steps:
+      - uses: actions/checkout@v2
+      - run: echo "deb [trusted=yes] https://dl.bintray.com/ooni/ooniprobe-debian/ unstable main" | sudo tee -a /etc/apt/sources.list.d/ooniprobe.list
+      - run: sudo apt update
+      - run: sudo apt install ooniprobe
+      - run: ooniprobe ${{ matrix.extraoptions }} im

--- a/.github/workflows/ooniprobe3debian.yml
+++ b/.github/workflows/ooniprobe3debian.yml
@@ -16,6 +16,6 @@ jobs:
       - uses: actions/checkout@v2
       - run: echo "deb [trusted=yes] https://dl.bintray.com/ooni/ooniprobe-debian/ unstable main" | sudo tee -a /etc/apt/sources.list.d/ooniprobe.list
       - run: sudo apt update
-      - run: sudo apt install ooniprobe
+      - run: sudo apt install ooniprobe-cli
       - run: ooniprobe onboard --yes
       - run: ooniprobe ${{ matrix.extraoptions }} im

--- a/.github/workflows/ooniprobe3debian.yml
+++ b/.github/workflows/ooniprobe3debian.yml
@@ -18,4 +18,4 @@ jobs:
       - run: sudo apt update
       - run: sudo apt install ooniprobe-cli
       - run: ooniprobe onboard --yes
-      - run: ooniprobe ${{ matrix.extraoptions }} im
+      - run: ooniprobe ${{ matrix.extraoptions }} run im

--- a/.github/workflows/probeengine.yml
+++ b/.github/workflows/probeengine.yml
@@ -7,7 +7,7 @@ on:
   pull_request:
   push:
   schedule:
-    - cron: "20 */2 * * *"
+    - cron: "25 */8 * * *"
 jobs:
   test:
     runs-on: "ubuntu-18.04"

--- a/.github/workflows/probeengine1.yml
+++ b/.github/workflows/probeengine1.yml
@@ -6,7 +6,7 @@ on:
   pull_request:
   push:
   schedule:
-    - cron: "25 */2 * * *"
+    - cron: "30 */8 * * *"
 jobs:
   test:
     runs-on: "ubuntu-18.04"

--- a/.github/workflows/probeengine2.yml
+++ b/.github/workflows/probeengine2.yml
@@ -6,7 +6,7 @@ on:
   pull_request:
   push:
   schedule:
-    - cron: "30 */2 * * *"
+    - cron: "35 */8 * * *"
 jobs:
   test:
     runs-on: "ubuntu-18.04"


### PR DESCRIPTION
While there relax the testing policy and test three times per
day, which is enough given we've flipped the API now.

This counts as progress for https://github.com/ooni/backend/issues/452

Future commits will further improve the tests we're running here.