### PR TITLE
Align the debian build CI to the official install guidelines

### DIFF
--- a/.github/workflows/ooniprobe3debian.yml
+++ b/.github/workflows/ooniprobe3debian.yml
@@ -16,7 +16,8 @@ jobs:
         - ""
     steps:
       - uses: actions/checkout@v2
-      - run: echo "deb [trusted=yes] https://dl.bintray.com/ooni/ooniprobe-debian/ unstable main" | sudo tee /etc/apt/sources.list.d/ooniprobe.list
+      - run: sudo apt-key adv --verbose --keyserver keyserver.ubuntu.com --recv-keys '8756C4F765C9AC3CB6B85D62379CE192D401AB61'
+      - run: echo "deb https://dl.bintray.com/ooni/ooniprobe-debian/ unstable main" | sudo tee /etc/apt/sources.list.d/ooniprobe.list
       - run: sudo apt update
       - run: sudo apt install ooniprobe-cli
       - run: ooniprobe onboard --yes


### PR DESCRIPTION
We have had reports of the key not working, so this aligns the CI to the official install instructions found here: https://ooni.org/install/cli/ubuntu-debian